### PR TITLE
Feature/add user_commands option (former extra_commands option)

### DIFF
--- a/tcs_garr/commands/acme.py
+++ b/tcs_garr/commands/acme.py
@@ -16,8 +16,8 @@ class AcmeAccountsCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, args, harica_config):
+        super().__init__(args, harica_config)
         self.command_name = "acme"
         self.help_text = "List ACME accounts configured in Harica"
 

--- a/tcs_garr/commands/acme.py
+++ b/tcs_garr/commands/acme.py
@@ -9,9 +9,9 @@ class AcmeAccountsCommand(BaseCommand):
     """
     Command to list available acme accounts and display their details.
 
-
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN

--- a/tcs_garr/commands/approve.py
+++ b/tcs_garr/commands/approve.py
@@ -60,15 +60,15 @@ class ApproveCommand(BaseCommand):
 
         if self.args.id:
             # Approve specific transactions by ID
-            self.__approve_transactions(self.args.id.split(","))
+            self._approve_transactions(self.args.id.split(","))
         elif self.args.all:
             # Approve all pending transactions
-            self.__approve_transactions()
+            self._approve_transactions()
         elif self.args.list_pending:
             # List all pending certificate requests
-            self.__list_pending_certificates()
+            self._list_pending_certificates()
 
-    def __approve_transactions(self, ids=None):
+    def _approve_transactions(self, ids=None):
         """
         Approves transactions by ID or approves all pending transactions.
 
@@ -100,7 +100,7 @@ class ApproveCommand(BaseCommand):
                 # Log error if trying to approve a certificate that the user cannot approve (own request)
                 self.logger.error(f"Failed to approve certificate with ID {id}. You cannot approve your own request.")
 
-    def __list_pending_certificates(self):
+    def _list_pending_certificates(self):
         """
         Lists all pending certificate requests.
 

--- a/tcs_garr/commands/approve.py
+++ b/tcs_garr/commands/approve.py
@@ -18,14 +18,14 @@ class ApproveCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.SSL_ENTERPRISE_APPROVER
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the ApproveCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "approve"
         self.help_text = "Approve a certificate by ID"
 

--- a/tcs_garr/commands/approve.py
+++ b/tcs_garr/commands/approve.py
@@ -14,6 +14,7 @@ class ApproveCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.SSL_ENTERPRISE_APPROVER

--- a/tcs_garr/commands/base.py
+++ b/tcs_garr/commands/base.py
@@ -6,7 +6,6 @@ from colorama import Fore, Style
 from tcs_garr.harica_client import HaricaClient
 from tcs_garr.logger import setup_logger
 from tcs_garr.notifications import NotificationManager
-from tcs_garr.utils import HaricaClientConfig
 
 
 def requires_any_role(*roles):
@@ -117,20 +116,18 @@ class BaseCommand(ABC):
 
     REQUIRED_ROLE = None
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
+        self.args = args
+        self.harica_config = harica_config
+
         # Default command name (can be overridden by subclasses)
         self.command_name = None
-
-        self.args = args
-
-        self.logger = setup_logger()
 
         # Default help text (should be overridden by subclasses)
         self.help_text = "No description available"
 
+        self.logger = setup_logger()
         self._harica_client = None
-
-        self._harica_config = None
 
     @abstractmethod
     def configure_parser(self, parser):
@@ -162,15 +159,6 @@ class BaseCommand(ABC):
 
         return self._harica_client
 
-    @property
-    def harica_config(self) -> HaricaClientConfig:
-        if not self._harica_config:
-            self._harica_config = HaricaClientConfig(
-                environment=self.args.environment,
-                alt_config_path=self.args.config,
-            )
-        return self._harica_config
-
     def check_required_role(self, client: HaricaClient):
         """Check if the user has the required role for the command."""
         if self.REQUIRED_ROLE and not client.has_role(self.REQUIRED_ROLE):
@@ -190,8 +178,8 @@ class BaseCommand(ABC):
         pass
 
     def call_webhook(self, cert_type, cn, cert_id=None):
-        webhook_url = self._harica_config.webhook_url
-        webhook_type = self._harica_config.webhook_type
+        webhook_url = self.harica_config.webhook_url
+        webhook_type = self.harica_config.webhook_type
         if webhook_url:
             try:
                 requestor = self._harica_client.email

--- a/tcs_garr/commands/base.py
+++ b/tcs_garr/commands/base.py
@@ -112,7 +112,13 @@ def requires_roles(*roles, logic="OR"):
 
 
 class BaseCommand(ABC):
-    """Base class that all command implementations should inherit from."""
+    """
+    Base class that all command implementations should inherit from.
+
+    Args:
+        args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
+    """
 
     REQUIRED_ROLE = None
 
@@ -168,14 +174,10 @@ class BaseCommand(ABC):
             exit(1)
 
     @abstractmethod
-    def execute(self, args):
+    def execute(self):
         """
-        Execute the command with the parsed arguments.
-
-        Args:
-            args: The parsed command arguments
+        Execute the command instance with its arguments and configuration. Must be implemented by subclasses.
         """
-        pass
 
     def call_webhook(self, cert_type, cn, cert_id=None):
         webhook_url = self.harica_config.webhook_url

--- a/tcs_garr/commands/base.py
+++ b/tcs_garr/commands/base.py
@@ -210,3 +210,13 @@ class BaseCommand(ABC):
 
             except Exception as e:
                 self.logger.error(f"Error sending webhook via NotificationManager: {e}")
+
+    def get_output_folder(self):
+        """
+        Retrieve the default output folder from the configuration.
+
+        Returns:
+            str: The output folder path from the configuration.
+        """
+        # Load environment-specific configuration
+        return self.harica_config.output_folder

--- a/tcs_garr/commands/cancel.py
+++ b/tcs_garr/commands/cancel.py
@@ -8,6 +8,7 @@ class CancelCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER

--- a/tcs_garr/commands/cancel.py
+++ b/tcs_garr/commands/cancel.py
@@ -12,14 +12,14 @@ class CancelCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the CancelCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "cancel"
         self.help_text = "Cancel a request by ID"
 

--- a/tcs_garr/commands/domains.py
+++ b/tcs_garr/commands/domains.py
@@ -21,14 +21,14 @@ class DomainsCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the DomainsCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "domains"
         self.help_text = "List available domains"
 

--- a/tcs_garr/commands/domains.py
+++ b/tcs_garr/commands/domains.py
@@ -17,6 +17,7 @@ class DomainsCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN

--- a/tcs_garr/commands/download.py
+++ b/tcs_garr/commands/download.py
@@ -26,8 +26,8 @@ class DownloadCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, args, harica_config):
+        super().__init__(args, harica_config)
         self.command_name = "download"
         self.help_text = "Download a certificate by ID"
 

--- a/tcs_garr/commands/download.py
+++ b/tcs_garr/commands/download.py
@@ -58,19 +58,6 @@ class DownloadCommand(BaseCommand):
             help="Type of download: 'pemBundle' or 'certificate'. Default is 'pemBundle'.",
         )
 
-    def get_output_folder(self):
-        """
-        Retrieve the default output folder from the configuration.
-
-        Args:
-            args (argparse.Namespace): The command-line arguments passed to the command.
-
-        Returns:
-            str: The output folder path from the configuration.
-        """
-        # Load environment-specific configuration
-        return self.harica_config.output_folder
-
     def get_trusted_intermediates(self):
         """
         Load all trusted intermediate certificates from the 'certs' folder.

--- a/tcs_garr/commands/download.py
+++ b/tcs_garr/commands/download.py
@@ -22,6 +22,7 @@ class DownloadCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER

--- a/tcs_garr/commands/init.py
+++ b/tcs_garr/commands/init.py
@@ -20,14 +20,14 @@ class InitCommand(BaseCommand):
         args (argparse.Namespace): The command-line arguments passed to the command.
     """
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the InitCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "init"
         self.help_text = "Generate Harica config file"
 

--- a/tcs_garr/commands/init.py
+++ b/tcs_garr/commands/init.py
@@ -18,6 +18,7 @@ class InitCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     def __init__(self, args, harica_config):

--- a/tcs_garr/commands/init.py
+++ b/tcs_garr/commands/init.py
@@ -89,6 +89,7 @@ class InitCommand(BaseCommand):
             "https_proxy": "",
             "webhook_url": "",
             "webhook_type": settings.WEBHOOK_TYPE,
+            "user_commands": "",
         }
 
         # Check if the configuration file already exists
@@ -199,6 +200,14 @@ class InitCommand(BaseCommand):
             else:
                 print(f"{Fore.RED}❌ Invalid webhook type. Must be 'slack' or 'generic'.{Style.RESET_ALL}")
 
+        # Prompt for output folder with existing value in brackets if force with existing config
+        user_commands_prompt = f"{Fore.GREEN}📂 Enter user_commands package folder"
+        if force and has_existing_config and existing_values["user_commands"]:
+            user_commands_prompt += f" [{existing_values['user_commands']}]"
+        user_commands = input(f"{user_commands_prompt}: {Style.RESET_ALL}") or (
+            existing_values["user_commands"] if force and has_existing_config else ""
+        )
+
         # Update the configuration with the user inputs
         config[section_name] = {
             "username": username,
@@ -216,6 +225,8 @@ class InitCommand(BaseCommand):
             config[section_name]["webhook_url"] = webhook_url
         if webhook_type:
             config[section_name]["webhook_type"] = webhook_type
+        if user_commands:
+            config[section_name]["user_commands"] = user_commands
 
         # Write the configuration to the file
         with open(settings.CONFIG_PATH, "w") as configfile:

--- a/tcs_garr/commands/k8s.py
+++ b/tcs_garr/commands/k8s.py
@@ -52,16 +52,6 @@ class K8sCommand(BaseCommand):
             help="Name for the yaml file without the extension (optional).",
         )
 
-    def get_output_folder(self):
-        """
-        Retrieve the default output folder from the configuration.
-
-        Returns:
-            str: The output folder path from the configuration.
-        """
-        # Load environment-specific configuration to get the output folder
-        return self.harica_config.output_folder
-
     def execute(self):
         """
         Executes the command to generate a Kubernetes TLS secret YAML file.

--- a/tcs_garr/commands/k8s.py
+++ b/tcs_garr/commands/k8s.py
@@ -12,6 +12,7 @@ class K8sCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     def __init__(self, args, harica_config):

--- a/tcs_garr/commands/k8s.py
+++ b/tcs_garr/commands/k8s.py
@@ -14,14 +14,14 @@ class K8sCommand(BaseCommand):
         args (argparse.Namespace): The command-line arguments passed to the command.
     """
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the K8sCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "k8s"
         self.help_text = "Generate Kubernetes TLS resource file"
 

--- a/tcs_garr/commands/list_certificates.py
+++ b/tcs_garr/commands/list_certificates.py
@@ -20,6 +20,10 @@ class ListCertificatesCommand(BaseCommand):
     expiration criteria provided by the user, such as certificates that have
     expired since a certain number of days or certificates expiring in the
     next few days.
+
+    Args:
+        args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER  # Base requirement for the whole command

--- a/tcs_garr/commands/list_certificates.py
+++ b/tcs_garr/commands/list_certificates.py
@@ -24,7 +24,7 @@ class ListCertificatesCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER  # Base requirement for the whole command
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initialize the ListCertificates class.
 
@@ -32,7 +32,7 @@ class ListCertificatesCommand(BaseCommand):
         The command name is "list", and it is used to generate reports about
         certificates. The `help_text` provides a brief description of the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "list"  # Set the command name to "list"
         self.help_text = "List and filter certificates"  # Help text for the command
 

--- a/tcs_garr/commands/request.py
+++ b/tcs_garr/commands/request.py
@@ -31,14 +31,14 @@ class RequestCommand(BaseCommand):
     HARICA_SAN_LIMIT = 100
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the RequestCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "request"
         self.help_text = "Request a new certificate"
         self.parser = None

--- a/tcs_garr/commands/request.py
+++ b/tcs_garr/commands/request.py
@@ -26,6 +26,7 @@ class RequestCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     HARICA_SAN_LIMIT = 100

--- a/tcs_garr/commands/request.py
+++ b/tcs_garr/commands/request.py
@@ -78,19 +78,6 @@ class RequestCommand(BaseCommand):
         create_group.add_argument("--cn", help="Common name of the certificate.")
         self.parser.add_argument("--alt_names", default="", help="Comma-separated alternative names (only used with --cn).")
 
-    def get_output_folder(self):
-        """
-        Retrieve the default output folder from the configuration.
-
-        Args:
-            args (argparse.Namespace): The command-line arguments passed to the command.
-
-        Returns:
-            str: The output folder path from the configuration.
-        """
-        # Load environment-specific configuration
-        return self.harica_config.output_folder
-
     def execute(self):
         """
         Executes the command to generate a CSR or request a certificate.

--- a/tcs_garr/commands/request.py
+++ b/tcs_garr/commands/request.py
@@ -92,19 +92,19 @@ class RequestCommand(BaseCommand):
 
         if self.args.cn:
             # Generate a CSR and request a certificate
-            csr_path = self.__generate_key_csr(self.args.cn, self.args.alt_names, self.harica_config.output_folder)
-            cn, certificate_id = self.__issue_certificate(csr_path, self.args.profile)
+            csr_path = self._generate_key_csr(self.args.cn, self.args.alt_names, self.harica_config.output_folder)
+            cn, certificate_id = self._issue_certificate(csr_path, self.args.profile)
         else:
             # CSR has been provided, just issue the certificate
-            cn, certificate_id = self.__issue_certificate(self.args.csr, self.args.profile)
+            cn, certificate_id = self._issue_certificate(self.args.csr, self.args.profile)
 
         if self.args.wait:
-            self.__wait_for_certificate_approval(cn, certificate_id)
+            self._wait_for_certificate_approval(cn, certificate_id)
 
         if not self.args.disable_webhook:
             self.call_webhook("TLS", cn, certificate_id)
 
-    def __generate_key_csr(self, cn, alt_names, output_folder):
+    def _generate_key_csr(self, cn, alt_names, output_folder):
         """
         Generates a private key and CSR for the specified common name and alternative names.
 
@@ -190,7 +190,7 @@ class RequestCommand(BaseCommand):
 
         return csr_path
 
-    def __issue_certificate(self, csr_file, profile):
+    def _issue_certificate(self, csr_file, profile):
         """
         Issues a certificate request by submitting a CSR to the Harica client.
 
@@ -247,7 +247,7 @@ class RequestCommand(BaseCommand):
             self.logger.error(f"{Fore.RED}CSR file {csr_file} not found.{Style.RESET_ALL}")
             exit(1)
 
-    def __wait_for_certificate_approval(self, cn, certificate_id):
+    def _wait_for_certificate_approval(self, cn, certificate_id):
         """
         Waits for the certificate to be approved by polling the Harica service.
 

--- a/tcs_garr/commands/revoke.py
+++ b/tcs_garr/commands/revoke.py
@@ -12,6 +12,7 @@ class RevokeCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER

--- a/tcs_garr/commands/revoke.py
+++ b/tcs_garr/commands/revoke.py
@@ -16,14 +16,14 @@ class RevokeCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the CancelCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "revoke"
         self.help_text = "Revoke a certificate by ID"
 

--- a/tcs_garr/commands/smime.py
+++ b/tcs_garr/commands/smime.py
@@ -34,14 +34,14 @@ class RequestCommand(BaseCommand):
     HARICA_BULK_EMAIL_LIMIT = 100
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the RequestCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "smime"
         self.help_text = "Request a new S/MIME certificate"
         self.parser = None

--- a/tcs_garr/commands/smime.py
+++ b/tcs_garr/commands/smime.py
@@ -102,19 +102,6 @@ class RequestCommand(BaseCommand):
             help="Type of download: 'pemBundle' or 'certificate'. Default is 'pemBundle'.",
         )
 
-    def get_output_folder(self):
-        """
-        Retrieve the default output folder from the configuration.
-
-        Args:
-            args (argparse.Namespace): The command-line arguments passed to the command.
-
-        Returns:
-            str: The output folder path from the configuration.
-        """
-        # Load environment-specific configuration
-        return self.harica_config.output_folder
-
     def execute(self):
         """
         Executes the command to generate a CSR or request a certificate and download it.

--- a/tcs_garr/commands/smime.py
+++ b/tcs_garr/commands/smime.py
@@ -29,6 +29,7 @@ class RequestCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     HARICA_BULK_EMAIL_LIMIT = 100

--- a/tcs_garr/commands/smime.py
+++ b/tcs_garr/commands/smime.py
@@ -119,11 +119,11 @@ class RequestCommand(BaseCommand):
                 self.parser.error("--emails takes at most 3 addresses.")
                 exit(1)
             # Generate a CSR and request a certificate
-            csr_path = self.__generate_key_csr(self.args.emails, self.args.gn, self.args.sn, self.harica_config.output_folder)
-            email, p7b_data = self.__issue_bulk_certificate(csr_path, self.args.profile)
+            csr_path = self._generate_key_csr(self.args.emails, self.args.gn, self.args.sn, self.harica_config.output_folder)
+            email, p7b_data = self._issue_bulk_certificate(csr_path, self.args.profile)
         else:
             # CSR has been provided, just issue the certificate
-            email, p7b_data = self.__issue_bulk_certificate(self.args.csr, self.args.profile)
+            email, p7b_data = self._issue_bulk_certificate(self.args.csr, self.args.profile)
 
         # since this API returns the certificate immediately, we do something similar to tcs_garr.commands.download.execute here.
         if self.args.download_type == "pemBundle":
@@ -155,7 +155,7 @@ class RequestCommand(BaseCommand):
         if not self.args.disable_webhook:
             self.call_webhook("S/MIME", email)
 
-    def __generate_key_csr(self, emails, gn, sn, output_folder):
+    def _generate_key_csr(self, emails, gn, sn, output_folder):
         """
         Generates a private key and CSR for the specified common name and alternative names.
 
@@ -227,7 +227,7 @@ class RequestCommand(BaseCommand):
 
         return csr_path
 
-    def __issue_bulk_certificate(self, csr_file, profile):
+    def _issue_bulk_certificate(self, csr_file, profile):
         """
         Issues a certificate request by submitting a CSR to the Harica client.
 

--- a/tcs_garr/commands/test_api.py
+++ b/tcs_garr/commands/test_api.py
@@ -17,8 +17,8 @@ class TestApiCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, args, harica_config):
+        super().__init__(args, harica_config)
         self.command_name = "test"
         self.help_text = "Test Harica API endpoints"
 

--- a/tcs_garr/commands/test_api.py
+++ b/tcs_garr/commands/test_api.py
@@ -10,9 +10,9 @@ class TestApiCommand(BaseCommand):
     """
     Command to test Harica API endpoints
 
-
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER

--- a/tcs_garr/commands/upgrade.py
+++ b/tcs_garr/commands/upgrade.py
@@ -11,6 +11,10 @@ class UpgradeCommand(BaseCommand):
     This command checks the current version of the application and compares it
     to the latest version available on PyPI. If a newer version is available,
     the application is upgraded automatically.
+
+    Args:
+        args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     def __init__(self, args, harica_config):
@@ -44,9 +48,6 @@ class UpgradeCommand(BaseCommand):
         This method checks the current version of the application and compares it
         to the latest version available on PyPI. If a newer version is available,
         it performs the upgrade process and logs the result.
-
-        Args:
-            args: Parsed command-line arguments (not used for this command).
         """
         # Get the current version of the application
         current_version = get_current_version()

--- a/tcs_garr/commands/upgrade.py
+++ b/tcs_garr/commands/upgrade.py
@@ -13,7 +13,7 @@ class UpgradeCommand(BaseCommand):
     the application is upgraded automatically.
     """
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initialize the UpgradeCommand class.
 
@@ -21,7 +21,7 @@ class UpgradeCommand(BaseCommand):
         The command name is "upgrade", and it is used to upgrade the current
         application to the latest version available on PyPI.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "upgrade"  # Set the command name to "upgrade"
         self.help_text = "Self-upgrade command for the app."  # Help text for the command
 

--- a/tcs_garr/commands/validate.py
+++ b/tcs_garr/commands/validate.py
@@ -17,14 +17,14 @@ class ValidateCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initializes the ValidateCommand class.
 
         Args:
             args (argparse.Namespace): The command-line arguments passed to the command.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "validate"
         self.help_text = "Create validation token for domains"
 

--- a/tcs_garr/commands/validate.py
+++ b/tcs_garr/commands/validate.py
@@ -13,6 +13,7 @@ class ValidateCommand(BaseCommand):
 
     Args:
         args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.ENTERPRISE_ADMIN

--- a/tcs_garr/commands/whoami.py
+++ b/tcs_garr/commands/whoami.py
@@ -14,7 +14,7 @@ class WhoamiCommand(BaseCommand):
 
     REQUIRED_ROLE = UserRole.USER
 
-    def __init__(self, args):
+    def __init__(self, args, harica_config):
         """
         Initialize the WhoamiCommand class.
 
@@ -22,7 +22,7 @@ class WhoamiCommand(BaseCommand):
         The command name is "whoami", and it will be used to get the current
         user's profile when executed.
         """
-        super().__init__(args)
+        super().__init__(args, harica_config)
         self.command_name = "whoami"  # Set the command name to "whoami"
         self.help_text = "Get logged in user profile"  # Help text for the command
 

--- a/tcs_garr/commands/whoami.py
+++ b/tcs_garr/commands/whoami.py
@@ -10,6 +10,10 @@ class WhoamiCommand(BaseCommand):
 
     This command interacts with the Harica API to retrieve the profile details
     of the user who is currently authenticated.
+
+    Args:
+        args (argparse.Namespace): The command-line arguments passed to the command.
+        harica_config (HaricaClientConfig): The harica client configuration instance.
     """
 
     REQUIRED_ROLE = UserRole.USER
@@ -45,9 +49,6 @@ class WhoamiCommand(BaseCommand):
         This method makes a call to the Harica client to fetch the current user's
         profile, including their full name and email address. It logs this
         information to the console in a formatted, colorized output.
-
-        Args:
-            args: Parsed command-line arguments (not used for this command).
         """
 
         # Log the user's full name and email in green-colored output

--- a/tcs_garr/harica_client.py
+++ b/tcs_garr/harica_client.py
@@ -807,12 +807,14 @@ class HaricaClient:
         if len(organizations) > 1:
             raise ValueError("Multiple organizations found.'")
 
-        organization = organizations[0].get('id')
+        organization = organizations[0].get("id")
 
         csvio = io.StringIO()
         writer = csv.writer(csvio)
-        writer.writerow(["FriendlyName","Email","Email2","Email3","GivenName","Surname","PickupPassword","CertType","CSR"]) # header
-        writer.writerow([email[0], email[0], email[1], email[2], gn, sn, "", cert_type, csr]) # cert data
+        writer.writerow(
+            ["FriendlyName", "Email", "Email2", "Email3", "GivenName", "Surname", "PickupPassword", "CertType", "CSR"]
+        )  # header
+        writer.writerow([email[0], email[0], email[1], email[2], gn, sn, "", cert_type, csr])  # cert data
         # Note: the example CSV supplied by Harica adds a trailing comma after the CSR (but not on the header line). seems to work without just fine.
         csvdata = csvio.getvalue()
 
@@ -825,7 +827,7 @@ class HaricaClient:
         data = self.__make_post_request(
             "/api/OrganizationAdmin/CreateBulkCertificatesSMIME", data=payload, content_type="multipart/form-data"
         )
-        if data.history: # empty if not redirected
+        if data.history:  # empty if not redirected
             # if user is not authorized, we get redirected to login page (status codes 308->200)
             raise PermissionError("User is not authorized, must be an admin.")
         zipped_certificates = data.content
@@ -834,7 +836,7 @@ class HaricaClient:
         try:
             zipio = io.BytesIO(zipped_certificates)
             zipf = zipfile.ZipFile(zipio, "r")
-            p7b_data = next(zipf.read(name) for name in zipf.namelist()) # only contains 1 file, named "1.<FriendlyName>.p7b"
+            p7b_data = next(zipf.read(name) for name in zipf.namelist())  # only contains 1 file, named "1.<FriendlyName>.p7b"
         except Exception as e:
             raise ValueError("could not extract certificate from response")
 

--- a/tcs_garr/main.py
+++ b/tcs_garr/main.py
@@ -9,12 +9,12 @@ from packaging import version
 
 from tcs_garr.commands.base import BaseCommand
 from tcs_garr.logger import setup_logger
-from tcs_garr.utils import check_pypi_version, get_current_version
+from tcs_garr.utils import check_pypi_version, get_current_version, HaricaClientConfig
 
 logger = setup_logger()
 
 
-def discover_commands(args):
+def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfig):
     command_classes = {}
     package = "tcs_garr"
     package_dir = os.path.join(os.path.dirname(__file__), "commands")
@@ -28,17 +28,15 @@ def discover_commands(args):
             for item_name, item in module.__dict__.items():
                 if inspect.isclass(item) and issubclass(item, BaseCommand) and item is not BaseCommand:
                     # Create an instance of the command class
-                    cmd_instance = item(args)
+                    cmd_instance = item(args, harica_config)
                     cmd_name = cmd_instance.command_name or item.__name__.replace("Command", "").lower()
                     command_classes[cmd_name] = cmd_instance
 
     return command_classes
 
 
-def main():
-    """
-    Main function to handle command line arguments and initiate the certificate issuance or listing process.
-    """
+def get_arguments_parser() -> argparse.ArgumentParser:
+    """Create argument parser for CLI application."""
     parser = argparse.ArgumentParser(description="Harica Certificate Manager")
 
     parser.add_argument("--debug", action="store_true", default=False, help="Enable DEBUG logging.")
@@ -52,15 +50,12 @@ def main():
         action="store_true",
         help="Skip checking for a new release",
     )
-    subparser = parser.add_subparsers(dest="command", help="Available commands")
-
     parser.add_argument(
         "--environment",
         choices=["production", "stg"],
         default="production",
         help="Specify the environment to use (default: production)",
     )
-
     parser.add_argument(
         "-c",
         "--config",
@@ -70,13 +65,31 @@ def main():
             "default path and will not use environment variables)"
         ),
     )
+    return parser
 
-    # Dynamically load commands
-    command_instances = discover_commands(None)
+
+def main(argv: list[str] = None):
+    """
+    Main function to handle command line arguments and initiate the certificate issuance or listing process.
+
+    :param argv: Command line arguments.
+    """
+    parser = get_arguments_parser()
+
+    # Parse know arguments and read/load the configuration once
+    args, _ = parser.parse_known_args()
+    harica_config = HaricaClientConfig(
+        environment=args.environment,
+        alt_config_path=args.config,
+    )
+
+    # Add subparsers and dynamically load commands
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+    command_instances = discover_commands(args, harica_config)
 
     for cmd_name, cmd_instance in command_instances.items():
         # Create a subparser for this command
-        command_parser = subparser.add_parser(cmd_name, help=cmd_instance.help_text)
+        command_parser = subparsers.add_parser(cmd_name, help=cmd_instance.help_text)
         # Let the command instance configure its parser
         cmd_instance.configure_parser(command_parser)
 
@@ -84,7 +97,7 @@ def main():
     args = parser.parse_args()
 
     # Now, pass the args to command discovery and update command instances
-    command_instances = discover_commands(args)
+    command_instances = discover_commands(args, harica_config)
 
     # Check for new release unless --no-check-release is specified
     if not args.no_check_release:

--- a/tcs_garr/main.py
+++ b/tcs_garr/main.py
@@ -68,16 +68,17 @@ def get_arguments_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] = None):
+def main(args=None):
     """
     Main function to handle command line arguments and initiate the certificate issuance or listing process.
 
-    :param argv: Command line arguments.
+    Args:
+        args (ist of str): CLI arguments provided for testing purposes. For default argparse use sys.argv[1:].
     """
     parser = get_arguments_parser()
 
     # Parse know arguments and read/load the configuration once
-    args, _ = parser.parse_known_args()
+    args, _ = parser.parse_known_args(args=args)
     harica_config = HaricaClientConfig(
         environment=args.environment,
         alt_config_path=args.config,
@@ -93,11 +94,8 @@ def main(argv: list[str] = None):
         # Let the command instance configure its parser
         cmd_instance.configure_parser(command_parser)
 
-    # Parse arguments
-    args = parser.parse_args()
-
-    # Now, pass the args to command discovery and update command instances
-    command_instances = discover_commands(args, harica_config)
+    # Update parsed arguments instance using all CLI arguments
+    parser.parse_args(namespace=args)
 
     # Check for new release unless --no-check-release is specified
     if not args.no_check_release:

--- a/tcs_garr/main.py
+++ b/tcs_garr/main.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import pkgutil
 from packaging import version
+from typing import Optional
 
 from tcs_garr.commands.base import BaseCommand
 from tcs_garr.logger import setup_logger
@@ -14,8 +15,15 @@ from tcs_garr.utils import check_pypi_version, get_current_version, HaricaClient
 logger = setup_logger()
 
 
-def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfig):
-    command_classes = {}
+def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfig) -> dict[str, BaseCommand]:
+    """
+    Returns a dictionary with instances of discovered commands.
+
+    Args:
+        args (Namespace): CLI arguments provided for testing purposes. It could be initially empty.
+        harica_config (HaricaClientConfig): Harica client configuration to initialize the harica client.
+    """
+    command_instances = {}
     package = "tcs_garr"
     package_dir = os.path.join(os.path.dirname(__file__), "commands")
 
@@ -30,14 +38,19 @@ def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfi
                     # Create an instance of the command class
                     cmd_instance = item(args, harica_config)
                     cmd_name = cmd_instance.command_name or item.__name__.replace("Command", "").lower()
-                    command_classes[cmd_name] = cmd_instance
+                    command_instances[cmd_name] = cmd_instance
 
-    return command_classes
+    return command_instances
 
 
-def get_arguments_parser() -> argparse.ArgumentParser:
-    """Create argument parser for CLI application."""
-    parser = argparse.ArgumentParser(prog="tcs-garr", description="Harica Certificate Manager")
+def get_arguments_parser(commands: Optional[dict[str, BaseCommand]] = None) -> argparse.ArgumentParser:
+    """
+    Create argument parser for CLI application.
+
+    Args:
+        commands: Add subparsers for command instances. Defaults to None.
+    """
+    parser = argparse.ArgumentParser(prog="tcs-garr", add_help=bool(commands), description="Harica Certificate Manager")
 
     parser.add_argument("--debug", action="store_true", default=False, help="Enable DEBUG logging.")
     parser.add_argument(
@@ -50,6 +63,14 @@ def get_arguments_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip checking for a new release",
     )
+    if commands:
+        subparsers = parser.add_subparsers(dest="command", help="Available commands")
+        for cmd_name, cmd_instance in commands.items():
+            # Create a subparser for this command
+            command_parser = subparsers.add_parser(cmd_name, help=cmd_instance.help_text)
+            # Let the command instance configure its parser
+            cmd_instance.configure_parser(command_parser)
+
     parser.add_argument(
         "--environment",
         choices=["production", "stg"],
@@ -68,33 +89,25 @@ def get_arguments_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(args=None):
+def main(argv: Optional[list[str]] = None):
     """
     Main function to handle command line arguments and initiate the certificate issuance or listing process.
 
     Args:
-        args (ist of str): CLI arguments provided for testing purposes. For default argparse use sys.argv[1:].
+        argv (optional list of str): arguments provided for non CLI usage. For default argparse use sys.argv[1:].
     """
-    parser = get_arguments_parser()
-
-    # Parse know arguments and read/load the configuration once
-    args, _ = parser.parse_known_args(args=args)
+    # Parse known arguments in order to load configuration by --config option, if any.
+    args, unknown = get_arguments_parser().parse_known_args(args=argv)
     harica_config = HaricaClientConfig(
         environment=args.environment,
         alt_config_path=args.config,
     )
 
-    # Add subparsers and dynamically load commands
-    subparsers = parser.add_subparsers(dest="command", help="Available commands")
-    command_instances = discover_commands(args, harica_config)
+    # Dynamically load commands and get the full argument parser
+    commands_instances = discover_commands(args, harica_config)
+    parser = get_arguments_parser(commands=commands_instances)
 
-    for cmd_name, cmd_instance in command_instances.items():
-        # Create a subparser for this command
-        command_parser = subparsers.add_parser(cmd_name, help=cmd_instance.help_text)
-        # Let the command instance configure its parser
-        cmd_instance.configure_parser(command_parser)
-
-    # Update parsed arguments instance using all CLI arguments
+    # Parse the arguments updating args instance using all CLI arguments
     parser.parse_args(namespace=args)
 
     if args.command != "init":
@@ -117,8 +130,8 @@ def main(args=None):
             logger.info(f"New version available: {latest_version}. Please consider updating with command tcs-garr upgrade.")
 
     # Execute the selected command
-    if args.command in command_instances:
-        command_instance = command_instances[args.command]
+    if args.command in commands_instances:
+        command_instance = commands_instances[args.command]
         command_instance.execute()
     else:
         parser.print_help()

--- a/tcs_garr/main.py
+++ b/tcs_garr/main.py
@@ -37,7 +37,7 @@ def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfi
 
 def get_arguments_parser() -> argparse.ArgumentParser:
     """Create argument parser for CLI application."""
-    parser = argparse.ArgumentParser(description="Harica Certificate Manager")
+    parser = argparse.ArgumentParser(prog="tcs-garr", description="Harica Certificate Manager")
 
     parser.add_argument("--debug", action="store_true", default=False, help="Enable DEBUG logging.")
     parser.add_argument(
@@ -96,6 +96,13 @@ def main(args=None):
 
     # Update parsed arguments instance using all CLI arguments
     parser.parse_args(namespace=args)
+
+    if args.command != "init":
+        # Check configuration only if the invoked command is not 'init'
+        try:
+            harica_config.validate_config()
+        except (OSError, TypeError, ValueError):
+            exit(1)
 
     # Check for new release unless --no-check-release is specified
     if not args.no_check_release:

--- a/tcs_garr/main.py
+++ b/tcs_garr/main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-
+import sys
 import argparse
 import importlib
 import inspect
 import os
+import pathlib
 import pkgutil
 from packaging import version
 from typing import Optional
@@ -38,6 +39,41 @@ def discover_commands(args: argparse.Namespace, harica_config: HaricaClientConfi
                     # Create an instance of the command class
                     cmd_instance = item(args, harica_config)
                     cmd_name = cmd_instance.command_name or item.__name__.replace("Command", "").lower()
+                    command_instances[cmd_name] = cmd_instance
+
+    if harica_config.user_commands:
+        # Load user defined commands from a local package directory
+        package_dir = pathlib.Path(harica_config.user_commands)
+        if not package_dir.is_dir():
+            logger.error(f"Extra commands directory not found at {package_dir}")
+            return command_instances
+
+        modules = []
+        for m_info in pkgutil.iter_modules([package_dir]):
+            if not m_info.ispkg and not m_info.name.startswith("_") and m_info.name not in ("base", "main", "utils"):
+                modules.append(m_info.name)
+
+        if not modules:
+            logger.error(f"Extra modules not found at {package_dir}")
+        elif str(package_dir.parent) not in sys.path:
+            sys.path.append(str(package_dir.parent))
+
+        for name in modules:
+            module = importlib.import_module(f"{package_dir.name}.{name}")
+
+            for item_name, item in module.__dict__.items():
+                if inspect.isclass(item) and issubclass(item, BaseCommand):
+                    if item is BaseCommand:
+                        continue
+
+                    # Create an instance of the command class
+                    cmd_instance = item(args, harica_config)
+                    cmd_name = cmd_instance.command_name or item.__name__.replace("Command", "").lower()
+
+                    if cmd_name in command_instances and not isinstance(cmd_instance, command_instances[cmd_name].__class__):
+                        logger.error(f"Invalid command {cmd_name!r} override from {module!r}!")
+                        continue
+
                     command_instances[cmd_name] = cmd_instance
 
     return command_instances

--- a/tcs_garr/utils.py
+++ b/tcs_garr/utils.py
@@ -116,18 +116,20 @@ class HaricaClientConfig:
                     # Found config, no need to check further
                     break
                 else:
-                    logger.error(f"No configuration found for environment '{environment}' in {path}")
-                    exit(1)
+                    error_msg = f"No configuration found for environment '{environment}' in {path}"
+                    logger.error(f"❌ {error_msg}")
+                    raise OSError(error_msg)
 
         # No fallback to env variables if alt_config_path is provided and config file is
         # not found
         if not config_data and alt_config_path:
-            logger.error(f"Alternative config file '{alt_config_path}' not found.")
-            exit(1)
+            error_msg = f"Alternative config file '{alt_config_path}' not found."
+            logger.error(f"❌ {error_msg}")
+            raise OSError(error_msg)
 
         # Fallback to env variables if no config file
         if config_data is None:
-            logger.info("No config file found. Falling back to environment variables.")
+            logger.info("\u26a0 No config file found. Falling back to environment variables.")
             config_data = {
                 "username": os.getenv("HARICA_USERNAME"),
                 "password": os.getenv("HARICA_PASSWORD"),
@@ -139,19 +141,7 @@ class HaricaClientConfig:
                 "webhook_type": os.getenv("HARICA_WEBHOOK_TYPE") or os.getenv("WEBHOOK_TYPE"),
             }
 
-            # Ensure all required environment variables are set
-            if not all([config_data["username"], config_data["password"]]):
-                logger.error(
-                    "Configuration file or environment variables missing. "
-                    "Generate config file with 'tcs-garr init' command or set "
-                    "HARICA_USERNAME and HARICA_PASSWORD "
-                    "environment variables."
-                )
-                exit(1)
-
-        self._validate_config(config_data)
-
-        # Set object attributes from config_data
+        # Set object attributes from config_data, check later against the provided ergs.
         self.username = config_data["username"]
         self.password = config_data["password"]
         self.totp_seed = config_data["totp_seed"]
@@ -161,25 +151,40 @@ class HaricaClientConfig:
         self.webhook_url = config_data["webhook_url"]
         self.webhook_type = config_data["webhook_type"]
 
-    def _validate_config(self, config_data):
+    def as_dict(self):
+        return self.__dict__.copy()
+
+    def validate_config(self, config_data=None):
         """
         Validate the configuration data.
 
         Args:
-            config_data (dict): Configuration data to validate.
+            config_data (dict): Configuration data to validate. If not provided validate instance.
         """
-        mandatory_fields = ["username", "password", "output_folder"]
-        missing_fields = [key for key in mandatory_fields if not config_data.get(key)]
+        if config_data is None:
+            config_data = self.as_dict()
+
+        # Ensure all required environment variables are set
+        missing_fields = [
+            k for k in ("username", "password", "output_folder") if not (v := config_data.get(k)) or not isinstance(v, str)
+        ]
         if missing_fields:
-            logger.error(f"❌ Missing mandatory configuration values for: {', '.join(missing_fields)}")
-            exit(1)
+            error_msg = (
+                "Configuration file or environment variables missing for "
+                f"configuration fields {', '.join(missing_fields)}. \n"
+                "Generate config file with 'tcs-garr init' command or set "
+                "HARICA_USERNAME and HARICA_PASSWORD environment variables."
+            )
+            logger.error(f"❌ {error_msg}")
+            raise TypeError(error_msg)
 
         # Validate email
         pattern = r"^[\w\.-]+@[\w\.-]+\.\w+$"
-        valid = re.match(pattern, config_data["username"])
+        valid = re.match(pattern, self.username)
         if not valid:
-            logger.error(f"❌ Invalid email format for username: {config_data['username']}")
-            exit(1)
+            error_msg = f"Invalid email format for username: {self.username}"
+            logger.error(f"❌ {error_msg}")
+            raise ValueError(error_msg)
 
         # Validate TOTP seed if provided
         totp_seed = config_data["totp_seed"]
@@ -187,8 +192,9 @@ class HaricaClientConfig:
             try:
                 generate_otp(totp_seed)
             except ValueError:
-                logger.error(f"❌ Invalid TOTP seed: {totp_seed}")
-                exit(1)
+                error_msg = f"Invalid TOTP seed: {totp_seed}"
+                logger.error(f"❌ {error_msg}")
+                raise ValueError(error_msg)
 
 
 def generate_otp(totp_seed):

--- a/tcs_garr/utils.py
+++ b/tcs_garr/utils.py
@@ -70,6 +70,7 @@ class HaricaClientConfig:
         self.https_proxy = None
         self.webhook_url = None
         self.webhook_type = None
+        self.user_commands = None
 
         # Load configuration
         self._load_config(environment, alt_config_path)
@@ -112,6 +113,7 @@ class HaricaClientConfig:
                         "https_proxy": config.get(section_name, "https_proxy", fallback=None),
                         "webhook_url": config.get(section_name, "webhook_url", fallback=None),
                         "webhook_type": config.get(section_name, "webhook_type", fallback=settings.WEBHOOK_TYPE),
+                        "user_commands": config.get(section_name, "user_commands", fallback=None),
                     }
                     # Found config, no need to check further
                     break
@@ -139,6 +141,7 @@ class HaricaClientConfig:
                 "https_proxy": os.getenv("HARICA_HTTPS_PROXY") or os.getenv("HTTPS_PROXY"),
                 "webhook_url": os.getenv("HARICA_WEBHOOK_URL") or os.getenv("WEBHOOK_URL"),
                 "webhook_type": os.getenv("HARICA_WEBHOOK_TYPE") or os.getenv("WEBHOOK_TYPE"),
+                "user_commands": None,  # Config only, don't want to import extra code by env settings.
             }
 
         # Set object attributes from config_data, check later against the provided ergs.
@@ -150,6 +153,7 @@ class HaricaClientConfig:
         self.https_proxy = config_data["https_proxy"]
         self.webhook_url = config_data["webhook_url"]
         self.webhook_type = config_data["webhook_type"]
+        self.user_commands = config_data["user_commands"]
 
     def as_dict(self):
         return self.__dict__.copy()

--- a/tests/data/test-tcs-garr.conf
+++ b/tests/data/test-tcs-garr.conf
@@ -1,0 +1,6 @@
+[harica]
+username = dummy@tcs-garr.test
+password = ****************
+totp_seed = otpauth://totp/TEST:dummy@tcs-garr.test?secret=JBSWY3DPEHPK3PXP&issuer=TEST
+output_folder = /tmp/dummy/harica_certificates
+webhook_type = generic

--- a/tests/tcs_garr_userspace/user_commands.py
+++ b/tests/tcs_garr_userspace/user_commands.py
@@ -1,0 +1,55 @@
+from colorama import Fore, Style
+
+from tcs_garr.commands.base import BaseCommand
+from tcs_garr.commands.whoami import WhoamiCommand
+from tcs_garr.utils import UserRole
+
+
+class DummyCommand(BaseCommand):
+    """
+    Command to test adding user extra commands by config.
+    """
+
+    REQUIRED_ROLE = UserRole.USER
+
+    def __init__(self, args, harica_config):
+        super().__init__(args, harica_config)
+        self.command_name = "dummy"
+        self.help_text = "Dummy user command for testing purposes."
+
+    def configure_parser(self, parser):
+        parser.add_argument("--dummy", action="store_true", help="Dummy option.")
+
+    def execute(self):
+        # Log the user's full name and email in green-colored output
+        self.logger.info(f"{Fore.GREEN}👤 Hi! Your dummy option is {self.args.dummy}")
+
+
+class InvalidWhoamiOverride(BaseCommand):
+    REQUIRED_ROLE = UserRole.USER
+
+    def __init__(self, args, harica_config):
+        super().__init__(args, harica_config)
+        self.command_name = "whoami"  # Set the command name to "whoami"
+        self.help_text = "Get logged in user profile"  # Help text for the command
+
+    def configure_parser(self, parser):
+        pass  # No arguments needed for this command
+
+    def execute(self):
+        # Log the user's full name and email in green-colored output
+        self.logger.info(
+            f"{Fore.GREEN}👤 Hi! You're logged in as {self.harica_client.full_name} ({self.harica_client.email}) on {self.args.environment} environment{Style.RESET_ALL}"
+        )
+        self.logger.info(
+            f"{Fore.GREEN}🔒 You have the following roles: {self.harica_client.get_user_roles()}{Style.RESET_ALL}"
+        )
+
+
+class WhoamiOverride(WhoamiCommand):
+    def execute(self):
+        # Log the user's full name and email in red-colored output
+        self.logger.info(
+            f"{Fore.RED}👤 Hi! You're logged in as {self.harica_client.full_name} ({self.harica_client.email}) on {self.args.environment} environment{Style.RESET_ALL}"
+        )
+        self.logger.info(f"{Fore.RED}🔒 You have the following roles: {self.harica_client.get_user_roles()}{Style.RESET_ALL}")

--- a/tests/test_tcs_garr.py
+++ b/tests/test_tcs_garr.py
@@ -1,20 +1,21 @@
 import unittest
 import io
 import pathlib
+from unittest.mock import patch
 from contextlib import redirect_stdout, redirect_stderr
 
-from tcs_garr.main import main
+from tcs_garr.main import logger, main
+import tcs_garr.utils
 
 
 class TestCommandLineInterface(unittest.TestCase):
-    TEST_CONFIG_FILE = pathlib.Path(__name__).parent / "data" / "test-tcs-garr.conf"
+    TEST_CONFIG_FILE = pathlib.Path(__file__).parent / "data" / "test-tcs-garr.conf"
 
     def exec_main(self, argv, exc=None):
         """Execute main() function and returns stdout and stderr produced by the call."""
         if "--config" not in argv:
             argv = argv + ["--config", str(self.TEST_CONFIG_FILE)]
 
-        print(argv)
         with redirect_stdout(io.StringIO()) as out, redirect_stderr(io.StringIO()) as err:
             if exc is None:
                 main(argv)
@@ -25,13 +26,31 @@ class TestCommandLineInterface(unittest.TestCase):
         return out.getvalue().strip(), err.getvalue().strip()
 
     def test_main_options(self):
-        out, err = self.exec_main(argv=["--help"], exc=SystemExit)
-        self.assertTrue(out.lstrip().startswith("usage: tcs-garr [-h]"))
+        out, err = self.exec_main(argv=["--help"])
+        self.assertTrue("usage: tcs-garr [-h]" in out)
         self.assertEqual(err, "")
 
+        # --version calls importlib.metadata.version() helper and the exit(0)
         out, err = self.exec_main(argv=["--version"], exc=SystemExit)
         self.assertRegex(out, r"\d+(\.\d+)*((a|b|rc)\d+)?")
         self.assertEqual(err, "")
+
+        with patch.object(tcs_garr.main, "get_current_version", return_value="0.1.0"):
+            with self.assertLogs(logger=logger, level="INFO") as cm:
+                self.exec_main(argv=["whoami"])
+                self.assertEqual(len(cm.output), 1)
+                self.assertIn("New version available:", cm.output[0])
+
+            with self.assertNoLogs(logger=logger, level="INFO"):
+                self.exec_main(argv=["whoami", "--no-check-release"])
+
+        with self.assertLogs(logger=logger, level="ERROR") as cm:
+            self.exec_main(argv=["--config", "unknown-file"], exc=OSError)
+            self.assertEqual(len(cm.output), 1)
+            self.assertIn("Alternative config file", cm.output[0])
+
+        _, err = self.exec_main(argv=["--environment", "foo"], exc=SystemExit)
+        self.assertIn("--environment: invalid choice: 'foo'", err)
 
 
 if __name__ == "__main__":

--- a/tests/test_tcs_garr.py
+++ b/tests/test_tcs_garr.py
@@ -1,6 +1,7 @@
 import unittest
 import io
 import pathlib
+import tempfile
 from unittest.mock import patch
 from contextlib import redirect_stdout, redirect_stderr
 
@@ -51,6 +52,23 @@ class TestCommandLineInterface(unittest.TestCase):
 
         _, err = self.exec_main(argv=["--environment", "foo"], exc=SystemExit)
         self.assertIn("--environment: invalid choice: 'foo'", err)
+
+    def test_user_commands(self):
+        package_dir = self.TEST_CONFIG_FILE.parent.parent / "tcs_garr_userspace"
+
+        with tempfile.NamedTemporaryFile() as tf:
+            with pathlib.Path(self.TEST_CONFIG_FILE).open("r") as fp:
+                config = fp.read() + f"\nuser_commands = {package_dir}"
+
+            tf.write(config.encode())
+            tf.flush()
+
+            with self.assertLogs(logger=logger, level="ERROR") as cm:
+                out, err = self.exec_main(argv=["--help", "--config", tf.name])
+                self.assertIn("Dummy user command", out)
+                self.assertEqual(err, "")
+                self.assertEqual(len(cm.output), 1)
+                self.assertIn("Invalid command 'whoami' override", cm.output[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_tcs_garr.py
+++ b/tests/test_tcs_garr.py
@@ -1,0 +1,38 @@
+import unittest
+import io
+import pathlib
+from contextlib import redirect_stdout, redirect_stderr
+
+from tcs_garr.main import main
+
+
+class TestCommandLineInterface(unittest.TestCase):
+    TEST_CONFIG_FILE = pathlib.Path(__name__).parent / "data" / "test-tcs-garr.conf"
+
+    def exec_main(self, argv, exc=None):
+        """Execute main() function and returns stdout and stderr produced by the call."""
+        if "--config" not in argv:
+            argv = argv + ["--config", str(self.TEST_CONFIG_FILE)]
+
+        print(argv)
+        with redirect_stdout(io.StringIO()) as out, redirect_stderr(io.StringIO()) as err:
+            if exc is None:
+                main(argv)
+            else:
+                with self.assertRaises(exc):
+                    main(argv)
+
+        return out.getvalue().strip(), err.getvalue().strip()
+
+    def test_main_options(self):
+        out, err = self.exec_main(argv=["--help"], exc=SystemExit)
+        self.assertTrue(out.lstrip().startswith("usage: tcs-garr [-h]"))
+        self.assertEqual(err, "")
+
+        out, err = self.exec_main(argv=["--version"], exc=SystemExit)
+        self.assertRegex(out, r"\d+(\.\d+)*((a|b|rc)\d+)?")
+        self.assertEqual(err, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi,
this PR is related to question issue #15.

Proposed changes are related on cleaning the initialization of CLI entry point main(), the argument parser installation and detection of subparsers from loaded commands. This let to load client configuration once, instead of reloading/rebuilding 
multiple times whitin commands.

This let also discover and build commands only once, giving them a minimal *args* Namespace, that is updated after with a full argument parser. For doing this configuration is added to command *__init__* args.

The following commits are related to the subject of this proposal, that is the adding of *extra_commands* option. This option unlock the possibility of extending existing or adding new command to a local installation, without requiring/waiting for an update of the available commands of the tool. This could be useful for whom that have to implement a specific additional actions on certificates base without recurring to external scripts (taking profit of the tool and its settings and of many Python tools available). 

The latest two commits are about the adding a small optional API (non loaded when the package is used from CLI ...) to the package, that provides a mode of using defined commands (or extra ones added locally) with a proxy class, e.g.:

```pycon
>>> from tcs_garr.api import CommandRunner
>>> runner = CommandRunner()
>>> result = runner.run('whoami')
```

I wish the changes will be accepted because the shortening in certificate duration force to develop something for improve certificate management (e.g. adding a local command for installation of certificates within your context).

This PR is alternative to PR #13, that should be close (or in any case, if the idea of PR #13 is of interest i could rework the proposal after the merge of this).

Thank you

Davide